### PR TITLE
Remove sentry requirement + fix integrations import + cosmetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*
 **/build/*
 *.pyc
 __pycache__
+.venv

--- a/sentry_googlechat/plugin.py
+++ b/sentry_googlechat/plugin.py
@@ -4,7 +4,7 @@ from sentry import tagstore
 from sentry.plugins.bases import notify
 from sentry.utils import json
 from sentry.http import safe_urlopen
-from sentry.integrations import FeatureDescription, IntegrationFeatures
+from sentry.integrations.base import FeatureDescription, IntegrationFeatures
 from sentry_plugins.base import CorePluginMixin
 
 from . import __version__, __doc__ as package_doc

--- a/sentry_googlechat/plugin.py
+++ b/sentry_googlechat/plugin.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from collections import defaultdict
-
 from sentry import tagstore
 from sentry.plugins.bases import notify
 from sentry.utils import json

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ to `Google Chat <https://gsuite.google.com/products/chat/>`_.
 
 from setuptools import setup, find_packages
 from sentry_googlechat import __version__
-import os
 
-cwd = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-readme_text = open(os.path.join(cwd, 'README.md')).read()
+
+with open('README.md', 'r') as f:
+    long_description = f.read()
 
 setup(
     name='sentry-googlechat',
@@ -22,14 +22,11 @@ setup(
     author='Jonhnny Weslley',
     author_email='jw@jonhnnyweslley.net',
     url='https://github.com/jweslley/sentry-googlechat',
-    long_description=readme_text,
+    long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',
     description='A Sentry plugin which posts notifications to Google Chat (https://gsuite.google.com/products/chat/).',
     packages=find_packages(),
-    install_requires=[
-      'sentry',
-    ],
     include_package_data=True,
     entry_points={
         'sentry.apps': [


### PR DESCRIPTION
Fix errors reported in #5 due to sentry yanking it from PyPI and not publishing new wheels. Just removing `sentry` from the `install_requires` fixes it.

Also, since 24.5.1, with the merge of https://github.com/getsentry/sentry/pull/71955 the path to the integrations objects we import has changed. They got adapted too