### PR TITLE
Improvements to notifications

### DIFF
--- a/sentry_googlechat/plugin.py
+++ b/sentry_googlechat/plugin.py
@@ -116,7 +116,7 @@ class GoogleChatPlugin(CorePluginMixin, notify.NotificationPlugin):
             if excluded_tags and (key in excluded_tags or std_key in excluded_tags):
                 continue
 
-            tags.append({ "keyValue": { "topLabel": tag_key.encode("utf-8"), "content": tag_value.encode("utf-8") }})
+            tags.append({ "keyValue": { "topLabel": tag_key, "content": tag_value }})
         return tags
 
     def notify(self, notification, raise_exception=False):
@@ -127,12 +127,12 @@ class GoogleChatPlugin(CorePluginMixin, notify.NotificationPlugin):
         if not self.is_configured(project):
             return
 
-        event_title = event.title.encode('utf-8')
-        event_message = event.message.encode('utf-8')
+        event_title = event.title
+        event_message = event.message
 
-        project_name = project.get_full_name().encode('utf-8')
+        project_name = project.get_full_name()
         if group.culprit:
-            culprit = group.culprit.encode("utf-8")
+            culprit = group.culprit
         else:
             culprit = None
 

--- a/sentry_googlechat/plugin.py
+++ b/sentry_googlechat/plugin.py
@@ -161,9 +161,16 @@ class GoogleChatPlugin(CorePluginMixin, notify.NotificationPlugin):
         sections.append({ "widgets": buttons })
 
         title = '[%s] %s' % (project_name, event_title)
-        payload = {"cards": [
-            { "header": { "title": title, "subtitle": event_message },
-             "sections": sections } ]}
+        text_message = '%s\n%s' % (title, event_message)
+        payload = {
+            "text": text_message,
+            "cards": [
+                {
+                    "header": {"title": title, "subtitle": event_message},
+                    "sections": sections,
+                }
+            ],
+        }
 
         webhook = self.get_option('webhook', project)
         return safe_urlopen(webhook, method='POST', data=json.dumps(payload))


### PR DESCRIPTION
When I receive notifications on Google from messages only containing a card, it shows up  saying that the webhook has sent me an attachment. This is not very useful and it means I need to view every message by opening the app every time.

This change adds the title and message as a chat text also above the card. This way we can see a summary in our notifications without needing to update the app.

While doing this I fixed something that had been also a bit annoying. Seeing `b'...'` for all the title strings.
We do not need to convert to utf-8 in python3. So I have also removed the redundant `.encode("utf-8")` sections (see images below for examples).
<img width="444" height="413" alt="Screenshot_20250908_144828" src="https://github.com/user-attachments/assets/82f1a71d-dd9d-43ec-908d-4d6cc4a44a9b" />
<img width="444" height="415" alt="Screenshot_20250908_144848" src="https://github.com/user-attachments/assets/261b0bd7-c867-40fd-af14-5d681bbecc6b" />


 